### PR TITLE
Removes unwraps

### DIFF
--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -298,7 +298,7 @@ impl Bug {
             board
                 .neighbors(position)
                 .iter()
-                .flat_map(|pieces| match pieces.last().unwrap().bug {
+                .flat_map(|pieces| match pieces.last().expect("Could not get last piece").bug {
                     Bug::Ant => Bug::ant_moves(position, board),
                     Bug::Beetle => Bug::beetle_moves(position, board),
                     Bug::Grasshopper => Bug::grasshopper_moves(position, board),
@@ -349,7 +349,7 @@ impl Bug {
             moves = moves
                 .iter()
                 .flat_map(|positions| {
-                    Bug::crawl(positions.last().unwrap(), &board)
+                    Bug::crawl(positions.last().expect("Could not get last piece"), &board)
                         .iter()
                         .map(|p| {
                             let mut pos = positions.clone();
@@ -372,7 +372,7 @@ impl Bug {
         });
         let mut positions = moves
             .iter()
-            .map(|positions| positions.last().unwrap().clone())
+            .map(|positions| positions.last().expect("Could not get last piece").clone())
             .collect::<Vec<Position>>();
         positions.sort_unstable();
         positions.dedup();

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -132,14 +132,15 @@ impl Bug {
         let mut moves = HashMap::new();
         if !board.pinned(position) {
             let positions = match board.top_bug(position) {
-                Bug::Ant => Bug::ant_moves(position, board),
-                Bug::Beetle => Bug::beetle_moves(position, board),
-                Bug::Grasshopper => Bug::grasshopper_moves(position, board),
-                Bug::Ladybug => Bug::ladybug_moves(position, board),
-                Bug::Mosquito => Bug::mosquito_moves(position, board),
-                Bug::Pillbug => Bug::pillbug_moves(position, board),
-                Bug::Queen => Bug::queen_moves(position, board),
-                Bug::Spider => Bug::spider_moves(position, board),
+                Some(Bug::Ant) => Bug::ant_moves(position, board),
+                Some(Bug::Beetle) => Bug::beetle_moves(position, board),
+                Some(Bug::Grasshopper) => Bug::grasshopper_moves(position, board),
+                Some(Bug::Ladybug) => Bug::ladybug_moves(position, board),
+                Some(Bug::Mosquito) => Bug::mosquito_moves(position, board),
+                Some(Bug::Pillbug) => Bug::pillbug_moves(position, board),
+                Some(Bug::Queen) => Bug::queen_moves(position, board),
+                Some(Bug::Spider) => Bug::spider_moves(position, board),
+                None => Vec::new(),
             };
             moves.insert(*position, positions);
         }
@@ -152,8 +153,8 @@ impl Bug {
         board: &Board,
     ) -> HashMap<Position, Vec<Position>> {
         match board.top_bug(position) {
-            Bug::Pillbug => Bug::pillbug_throw(position, board),
-            Bug::Mosquito
+            Some(Bug::Pillbug) => Bug::pillbug_throw(position, board),
+            Some(Bug::Mosquito)
                 if board.level(position) == 1 && board.neighbor_is_a(position, Bug::Pillbug) =>
             {
                 Bug::pillbug_throw(position, board)
@@ -298,16 +299,18 @@ impl Bug {
             board
                 .neighbors(position)
                 .iter()
-                .flat_map(|pieces| match pieces.last().expect("Could not get last piece").bug {
-                    Bug::Ant => Bug::ant_moves(position, board),
-                    Bug::Beetle => Bug::beetle_moves(position, board),
-                    Bug::Grasshopper => Bug::grasshopper_moves(position, board),
-                    Bug::Ladybug => Bug::ladybug_moves(position, board),
-                    Bug::Mosquito => vec![],
-                    Bug::Pillbug => Bug::pillbug_moves(position, board),
-                    Bug::Queen => Bug::queen_moves(position, board),
-                    Bug::Spider => Bug::spider_moves(position, board),
-                })
+                .flat_map(
+                    |pieces| match pieces.last().expect("Could not get last piece").bug {
+                        Bug::Ant => Bug::ant_moves(position, board),
+                        Bug::Beetle => Bug::beetle_moves(position, board),
+                        Bug::Grasshopper => Bug::grasshopper_moves(position, board),
+                        Bug::Ladybug => Bug::ladybug_moves(position, board),
+                        Bug::Mosquito => vec![],
+                        Bug::Pillbug => Bug::pillbug_moves(position, board),
+                        Bug::Queen => Bug::queen_moves(position, board),
+                        Bug::Spider => Bug::spider_moves(position, board),
+                    },
+                )
                 .collect()
         } else {
             Bug::beetle_moves(position, board)

--- a/engine/src/color.rs
+++ b/engine/src/color.rs
@@ -33,7 +33,10 @@ impl Color {
         match s {
             "w" => Ok(Color::White),
             "b" => Ok(Color::Black),
-            any => Err(GameError::ParsingError { found: any.to_string(), typ: "color string".to_string() }),
+            any => Err(GameError::ParsingError {
+                found: any.to_string(),
+                typ: "color string".to_string(),
+            }),
         }
     }
 

--- a/engine/src/game_error.rs
+++ b/engine/src/game_error.rs
@@ -10,10 +10,6 @@ pub enum GameError {
         turn: usize,
         reason: String,
     },
-    #[error("No piece found at position {position}")]
-    NoPieceAtPosition{
-        position: String,
-    },
     #[error("Invalid spawn of piece {piece} at position {position} on turn {turn}")]
     InvalidSpawn {
         piece: String,

--- a/engine/src/game_error.rs
+++ b/engine/src/game_error.rs
@@ -10,6 +10,10 @@ pub enum GameError {
         turn: usize,
         reason: String,
     },
+    #[error("No piece found at position {position}")]
+    NoPieceAtPosition{
+        position: String,
+    },
     #[error("Invalid spawn of piece {piece} at position {position} on turn {turn}")]
     InvalidSpawn {
         piece: String,

--- a/engine/src/history.rs
+++ b/engine/src/history.rs
@@ -38,51 +38,82 @@ impl History {
         self.moves.push((piece, pos));
     }
 
+    fn parse_game_result(&mut self, str: &str) {
+        let result = Regex::new(r"\[Result").expect("This regex should compile");
+        if result.is_match(str) {
+            match str {
+                "\"1-0\"]" => self.result = GameResult::Winner(Color::White),
+                "\"0-1\"]" => self.result = GameResult::Winner(Color::Black),
+                "\"1/2-1/2\"]" => self.result = GameResult::Draw,
+                _ => self.result = GameResult::Unknown,
+            }
+        }
+    }
+
+    fn parse_game_type(&mut self, line: &str) -> Result<(), GameError> {
+        let game_type_line = Regex::new(r"\[GameType.*").expect("This regex should compile");
+        let game_type =
+            Regex::new(r#"\[GameType "(Base[+MLP]?)"\]"#).expect("This regex should compile");
+        if game_type_line.is_match(&line) {
+            if let Some(caps) = game_type.captures(&line) {
+                if let Some(mtch) = caps.get(1) {
+                    self.game_type = GameType::from_str(mtch.as_str())?;
+                }
+            } else {
+                return Err(GameError::ParsingError {
+                    found: line.to_string(),
+                    typ: "game string".to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+    fn parse_turn(&mut self, tokens: &Vec<&str>) -> Result<(), GameError> {
+        let turn = Regex::new(r"\d+").expect("This regex should compile");
+        if let Some(token) = tokens.get(0) {
+            if turn.is_match(token) {
+                if let Some(piece) = tokens.get(1) {
+                    if let Some(position) = tokens.get(2) {
+                        self.moves.push((piece.to_string(), position.to_string()));
+                    } else {
+                        match *piece {
+                            "pass" => {
+                                self.moves.push(("pass".to_string(), "".to_string()));
+                            }
+                            _ if self.moves.is_empty() => {
+                                self.moves.push((piece.to_string(), ".".to_string()));
+                            }
+                            any => {
+                                return Err(GameError::ParsingError {
+                                    found: any.to_owned(),
+                                    typ: format!("move, in self on turn {}", token),
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub fn from_filepath(file_path: &str) -> Result<Self, GameError> {
         let mut history = History::new();
-        let header = Regex::new(r"\[.*").unwrap();
-        let turn = Regex::new(r"\d+").unwrap();
-        let result = Regex::new(r"\[Result").unwrap();
-        let game_type_line = Regex::new(r"\[GameType.*").unwrap();
-        let game_type = Regex::new(r#"\[GameType "(Base[+MLP]?)"\]"#).unwrap();
+        let header = Regex::new(r"\[.*").expect("This regex should compile");
         match File::open(file_path) {
             Ok(file) => {
                 for line in io::BufReader::new(file).lines().flatten() {
-                    let tokens = line.split_whitespace().collect::<Vec<&str>>();
                     if line.len() == 0 {
                         continue;
                     }
-                    if game_type_line.is_match(&line) {
-                        if let Some(caps) = game_type.captures(&line) {
-                            if let Some(mtch) = caps.get(1) {
-                                history.game_type = GameType::from_str(mtch.as_str())?;
-                            }
-                        } else {
-                            return Err(GameError::ParsingError { found: line.to_string(), typ: "game string".to_string() })
+                    let tokens = line.split_whitespace().collect::<Vec<&str>>();
+                    history.parse_game_type(&line)?;
+                    if let Some(token) = tokens.first() {
+                        history.parse_game_result(token);
+                        if header.is_match(token) {
+                            continue;
                         }
-                    }
-                    if result.is_match(tokens.first().unwrap()) {
-                        match tokens.get(1) {
-                            Some(&"\"1-0\"]") => history.result = GameResult::Winner(Color::White),
-                            Some(&"\"0-1\"]") => history.result = GameResult::Winner(Color::Black),
-                            Some(&"\"1/2-1/2\"]") => history.result = GameResult::Draw,
-                            _ => history.result = GameResult::Unknown,
-                        }
-                    }
-                    if header.is_match(tokens.first().unwrap()) {
-                        continue;
-                    }
-                    if turn.is_match(tokens.first().unwrap()) {
-                        if history.moves.is_empty() && tokens.get(2).is_none() {
-                            history
-                                .moves
-                                .push((tokens.get(1).unwrap().to_string(), ".".to_string()));
-                        } else {
-                            history.moves.push((
-                                tokens.get(1).unwrap().to_string(),
-                                tokens.get(2).unwrap_or(&"").to_string(),
-                            ));
-                        }
+                        history.parse_turn(&tokens)?;
                     }
                 }
             }

--- a/engine/src/piece.rs
+++ b/engine/src/piece.rs
@@ -30,7 +30,10 @@ impl Piece {
                 return Ok(Piece::new(bug, color, order));
             }
         }
-        return Err(GameError::ParsingError { found: s.to_string(), typ: "piece".to_string() });
+        return Err(GameError::ParsingError {
+            found: s.to_string(),
+            typ: "piece".to_string(),
+        });
     }
 
     pub fn is_color(&self, color: &Color) -> bool {

--- a/engine/src/piece.rs
+++ b/engine/src/piece.rs
@@ -17,13 +17,20 @@ impl Piece {
     }
 
     pub fn from_string(s: &str) -> Result<Piece, GameError> {
-        let color = Color::from_str(&s.chars().next().unwrap().to_string())?;
-        let bug = Bug::from_str(&s.chars().nth(1).unwrap().to_string())?;
-        let mut order = None;
-        if let Some(ch) = s.chars().nth(2) {
-            order = Some(ch.to_string().parse().unwrap());
+        if let Some(c_chars) = s.chars().next() {
+            let color = Color::from_str(&c_chars.to_string())?;
+            if let Some(b_chars) = s.chars().nth(1) {
+                let bug = Bug::from_str(&b_chars.to_string())?;
+                let mut order = None;
+                if let Some(ch) = s.chars().nth(2) {
+                    if let Ok(ord) = ch.to_string().parse() {
+                        order = Some(ord)
+                    }
+                }
+                return Ok(Piece::new(bug, color, order));
+            }
         }
-        Ok(Piece::new(bug, color, order))
+        return Err(GameError::ParsingError { found: s.to_string(), typ: "piece".to_string() });
     }
 
     pub fn is_color(&self, color: &Color) -> bool {

--- a/engine/src/position.rs
+++ b/engine/src/position.rs
@@ -87,47 +87,54 @@ impl Position {
             return Ok(Position(0, 0));
         }
 
-        let re = Regex::new(r"([-/\\]?)([wb][ABGMLPSQ]\d?)([-/\\]?)").unwrap();
-        let cap = re.captures(s).unwrap();
-        let piece = Piece::from_string(&cap[2])?;
-        let mut position = board.position(&piece);
-        if !cap[1].is_empty() {
-            match &cap[1] {
-                "\\" => {
-                    position = position.to(&Direction::NW);
-                }
-                "-" => {
-                    position = position.to(&Direction::W);
-                }
-                "/" => {
-                    position = position.to(&Direction::SW);
-                }
-                any => {
-                    return Err(GameError::InvalidDirection {
-                        direction: any.to_string(),
-                    })
-                }
-            }
-        }
-        if !cap[3].is_empty() {
-            match &cap[3] {
-                "/" => {
-                    position = position.to(&Direction::NE);
-                }
-                "-" => {
-                    position = position.to(&Direction::E);
-                }
-                "\\" => {
-                    position = position.to(&Direction::SE);
-                }
-                any => {
-                    return Err(GameError::InvalidDirection {
-                        direction: any.to_string(),
-                    })
+        let re = Regex::new(r"([-/\\]?)([wb][ABGMLPSQ]\d?)([-/\\]?)")
+            .expect("This regex should compile");
+        if let Some(cap) = re.captures(s) {
+            let piece = Piece::from_string(&cap[2])?;
+            let mut position = board.position(&piece)?;
+            if !cap[1].is_empty() {
+                match &cap[1] {
+                    "\\" => {
+                        position = position.to(&Direction::NW);
+                    }
+                    "-" => {
+                        position = position.to(&Direction::W);
+                    }
+                    "/" => {
+                        position = position.to(&Direction::SW);
+                    }
+                    any => {
+                        return Err(GameError::InvalidDirection {
+                            direction: any.to_string(),
+                        })
+                    }
                 }
             }
+            if !cap[3].is_empty() {
+                match &cap[3] {
+                    "/" => {
+                        position = position.to(&Direction::NE);
+                    }
+                    "-" => {
+                        position = position.to(&Direction::E);
+                    }
+                    "\\" => {
+                        position = position.to(&Direction::SE);
+                    }
+                    any => {
+                        return Err(GameError::InvalidDirection {
+                            direction: any.to_string(),
+                        })
+                    }
+                }
+            }
+            Ok(position)
+        } else {
+            Err(GameError::ParsingError {
+                found: s.to_string(),
+                typ: "position".to_string(),
+            })
         }
-        Ok(position)
     }
 }
 

--- a/engine/src/position.rs
+++ b/engine/src/position.rs
@@ -91,50 +91,50 @@ impl Position {
             .expect("This regex should compile");
         if let Some(cap) = re.captures(s) {
             let piece = Piece::from_string(&cap[2])?;
-            let mut position = board.position(&piece)?;
-            if !cap[1].is_empty() {
-                match &cap[1] {
-                    "\\" => {
-                        position = position.to(&Direction::NW);
-                    }
-                    "-" => {
-                        position = position.to(&Direction::W);
-                    }
-                    "/" => {
-                        position = position.to(&Direction::SW);
-                    }
-                    any => {
-                        return Err(GameError::InvalidDirection {
-                            direction: any.to_string(),
-                        })
-                    }
-                }
-            }
-            if !cap[3].is_empty() {
-                match &cap[3] {
-                    "/" => {
-                        position = position.to(&Direction::NE);
-                    }
-                    "-" => {
-                        position = position.to(&Direction::E);
-                    }
-                    "\\" => {
-                        position = position.to(&Direction::SE);
-                    }
-                    any => {
-                        return Err(GameError::InvalidDirection {
-                            direction: any.to_string(),
-                        })
+            if let Some(mut position) = board.position(&piece) {
+                if !cap[1].is_empty() {
+                    match &cap[1] {
+                        "\\" => {
+                            position = position.to(&Direction::NW);
+                        }
+                        "-" => {
+                            position = position.to(&Direction::W);
+                        }
+                        "/" => {
+                            position = position.to(&Direction::SW);
+                        }
+                        any => {
+                            return Err(GameError::InvalidDirection {
+                                direction: any.to_string(),
+                            })
+                        }
                     }
                 }
+                if !cap[3].is_empty() {
+                    match &cap[3] {
+                        "/" => {
+                            position = position.to(&Direction::NE);
+                        }
+                        "-" => {
+                            position = position.to(&Direction::E);
+                        }
+                        "\\" => {
+                            position = position.to(&Direction::SE);
+                        }
+                        any => {
+                            return Err(GameError::InvalidDirection {
+                                direction: any.to_string(),
+                            })
+                        }
+                    }
+                }
+                return Ok(position);
             }
-            Ok(position)
-        } else {
-            Err(GameError::ParsingError {
-                found: s.to_string(),
-                typ: "position".to_string(),
-            })
         }
+        return Err(GameError::ParsingError {
+            found: s.to_string(),
+            typ: "position".to_string(),
+        });
     }
 }
 

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -123,14 +123,18 @@ impl State {
             .len()
             > 1
         {
-            let pieces = self.board.board.get(&target_position).unwrap();
+            let pieces = self
+                .board
+                .board
+                .get(&target_position)
+                .expect("Target position cannot be empty because of 'if'");
             let len = pieces.len();
             let second_to_last = pieces[len - 2];
             pos = second_to_last.to_string();
         } else {
             // no piece at the current position, so it's a spawn or a move
             if let Some(neighbor_pos) = self.board.positions_taken_around(&target_position).get(0) {
-                let neighbor_piece = self.board.top_piece(neighbor_pos);
+                let neighbor_piece = self.board.top_piece_trusted(neighbor_pos);
                 let dir = neighbor_pos.direction(&target_position);
                 pos = dir.to_history_string(neighbor_piece.to_string());
             }
@@ -195,7 +199,7 @@ impl State {
     pub fn play_turn(&mut self, piece: Piece, target_position: Position) -> Result<(), GameError> {
         // If the piece is already in play, it's a move
         if self.board.piece_already_played(&piece) {
-            let current_position = self.board.position(&piece);
+            let current_position = self.board.position(&piece)?;
             if self.board.pinned(&current_position) {
                 return Err(GameError::InvalidMove {
                     piece: piece.to_string(),


### PR DESCRIPTION
We removed most of the unwraps, some are left, but they are in test cases. In some cases the unwraps were safe to keep, in these cases we changed them into `expect(...)` and gave them a meaningful message about why they are okay.

(side note: going through this we came up with a couple of future improvements, see the project)